### PR TITLE
BC-861 - to avoid the 100% load CPU don't use all processors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), "lib")
 
 require "bundler/gem_tasks"
+require "parallel_processor_count"
 require "wraith/save_images"
 require "wraith/crop"
 require "wraith/spider"

--- a/lib/parallel_processor_count.rb
+++ b/lib/parallel_processor_count.rb
@@ -1,0 +1,12 @@
+require "parallel"
+
+module Parallel
+  module ProcessorCount
+    alias_method :old_processor_count, :processor_count
+
+    # returns the numbers of processors divided by three
+    def processor_count
+      [1, (old_processor_count / 3.0).round].max
+    end
+  end
+end


### PR DESCRIPTION
* monkey-patched the `processor_count` method from `Parallel` gem to return the number processors divided by three