### PR TITLE
BC-861 - Limit the numbers of threads to one for ImageMagick tools.

### DIFF
--- a/configs/history.yaml
+++ b/configs/history.yaml
@@ -63,7 +63,7 @@ screen_widths:
   - 2880x1800
 
 # (optional) Resize to each screen width (efficient), or reload at each screen width (costly). Default: 'reload'
-resize_or_reload: 'resize'
+resize_or_reload: 'reload'
 
 # (required for history mode, otherwise optional) The directory that your base screenshots will be stored in.
 history_dir: 'shots_history'

--- a/lib/parallel_processor_count.rb
+++ b/lib/parallel_processor_count.rb
@@ -6,7 +6,7 @@ module Parallel
 
     # returns the numbers of processors divided by three
     def processor_count
-      [1, (old_processor_count / 3.0).round].max
+      [1, (old_processor_count / 2.0).round].max
     end
   end
 end

--- a/lib/wraith/compare_images.rb
+++ b/lib/wraith/compare_images.rb
@@ -31,7 +31,7 @@ class Wraith::CompareImages
   end
 
   def compare_task(base, compare, output, info)
-    cmdline = "compare -dissimilarity-threshold 1 -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base} #{compare.shellescape} #{output}"
+    cmdline = "compare -limit thread 1 -dissimilarity-threshold 1 -fuzz #{wraith.fuzz} -metric AE -highlight-color #{wraith.highlight_color} #{base} #{compare.shellescape} #{output}"
     px_value = Open3.popen3(cmdline) { |_stdin, _stdout, stderr, _wait_thr| stderr.read }.to_f
     begin
       img_size = ImageSize.path(output).size.inject(:*)

--- a/lib/wraith/crop.rb
+++ b/lib/wraith/crop.rb
@@ -41,7 +41,7 @@ class Wraith::CropImages
   end
 
   def run_crop_task(crop, height, width)
-    `convert #{crop.shellescape} -background none -extent #{width}x#{height} #{crop.shellescape}`
+    `convert -limit thread 1 #{crop.shellescape} -background none -extent #{width}x#{height} #{crop.shellescape}`
   end
 
   def image_dimensions(image)

--- a/lib/wraith/save_images.rb
+++ b/lib/wraith/save_images.rb
@@ -120,6 +120,6 @@ class Wraith::SaveImages
   end
 
   def set_image_width(image, width)
-    `convert #{image.shellescape} -background none -extent #{width}x0 #{image.shellescape}`
+    `convert -limit thread 1 #{image.shellescape} -background none -extent #{width}x0 #{image.shellescape}`
   end
 end

--- a/lib/wraith/thumbnails.rb
+++ b/lib/wraith/thumbnails.rb
@@ -24,6 +24,6 @@ class Wraith::Thumbnails
       FileUtils.mkdir_p(File.dirname(output_path))
     end
 
-    `convert #{png_path.shellescape} -thumbnail 200 -crop #{wraith.thumb_width.to_s}x#{wraith.thumb_height.to_s}+0+0 #{output_path.shellescape}`
+    `convert -limit thread 1 #{png_path.shellescape} -thumbnail 200 -crop #{wraith.thumb_width.to_s}x#{wraith.thumb_height.to_s}+0+0 #{output_path.shellescape}`
   end
 end


### PR DESCRIPTION
### Summary
* Limit the numbers of threads to one for ImageMagick tools. We need to do that because the ImageMagick algorithms execute on all the cores on your system in parallel, this if very eficient but also increases all the processors to 100% load.
* More info at: https://www.imagemagick.org/script/openmp.php
* changed the config to 'reload', 'resize' seems to have some bugs at this moment and sometimes is failing in taking screenshots