### PR TITLE
BC-1005: Remove School Edition Page from wraith (REVIEWED)

### DIFF
--- a/configs/history.yaml
+++ b/configs/history.yaml
@@ -30,7 +30,6 @@ paths:
    apps: /apps
    edtech: /professional-development/courses
    how_it_works: /content/how_it_works
-   school_edition: /schooledition
    signup: /subscription/new
    sign_in: /auth/users/sign_in
    standards: /state-standards


### PR DESCRIPTION
### Summary

* [BC-1005](https://lessonplanet.atlassian.net/browse/BC-1005)
* Removed school_edition page from paths